### PR TITLE
Fixes paths with spaces

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -6,24 +6,27 @@ local function execute(cmd, ...)
   vim.cmd(cmd)
 end
 
+local function trim(str)
+    return str:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
 local function is_lazygit_available()
     return fn.executable("lazygit") == 1
 end
 
 local function project_root_dir()
-
     -- try file location first
-    local gitdir = fn.system('cd ' .. fn.expand('%:p:h') .. ' && git rev-parse --show-toplevel')
+    local gitdir = fn.system('cd "' .. fn.expand('%:p:h') .. '" && git rev-parse --show-toplevel')
     local isgitdir = fn.matchstr(gitdir, '^fatal:.*') == ""
     if isgitdir then
-        return gitdir
+        return trim(gitdir)
     end
 
     -- try symlinked file location instead
-    local gitdir = fn.system('cd ' .. fn.fnamemodify(fn.resolve(fn.expand('%:p')), ':h') .. ' && git rev-parse --show-toplevel')
+    local gitdir = fn.system('cd "' .. fn.fnamemodify(fn.resolve(fn.expand('%:p')), ':h') .. '" && git rev-parse --show-toplevel')
     local isgitdir = fn.matchstr(gitdir, '^fatal:.*') == ""
     if isgitdir then
-        return gitdir
+        return trim(gitdir)
     end
 
     -- just return current working directory
@@ -42,7 +45,6 @@ local function exec_lazygit_command(cmd)
 end
 
 local function open_floating_window()
-
     local floating_window_scaling_factor = vim.g.lazygit_floating_window_scaling_factor
 
     if type(floating_window_scaling_factor) == 'table' then
@@ -158,11 +160,11 @@ local function lazygitconfig()
             -- directory does not exist
             fn.mkdir(fn.fnamemodify(config_file, ":h"))
         end
-        vim.cmd("edit " .. config_file)
+        vim.cmd('edit "' .. config_file .. '"')
         vim.cmd([[execute "silent! 0read !lazygit -c"]])
         vim.cmd([[execute "normal 1G"]])
     else
-        vim.cmd("edit " .. config_file)
+        vim.cmd('edit "' .. config_file .. '"')
     end
 end
 


### PR DESCRIPTION
As it is, when trying to call lazygit with a file that contains a space char in its path will fail, as the path will be broken into two arguments when passed to lazygit. The quotes I added fixes that. Then, there is the fact that the path returned by git has a newline at the end, so I trim the path to remove newlines at the beginning and end of paths. This version works with projects I have inside "Google Drive".

I DID NOT TEST THIS, but are basically the same changes I made on the other branch.