### PR TITLE
Add option to customize popup window corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following are configuration options and their defaults.
 ```vim
 let g:lazygit_floating_window_winblend = 0 " transparency of floating window
 let g:lazygit_floating_window_scaling_factor = 0.9 " scaling factor for floating window
+let g:lazygit_use_neovim_remote = ['╭', '╮', '╰', '╯'] " customize lazygit popup window corner characters
 ```
 
 Call `:LazyGit` to start a floating window with `lazygit`.

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -91,12 +91,20 @@ local function open_floating_window()
         height = height,
     }
 
-    local border_lines = {'╭' .. string.rep('─', width) .. '╮'}
+    local topleft, topright, botleft, botright
+    local corner_chars = vim.g.lazygit_floating_window_corner_chars
+    if type(corner_chars) == "table" and #corner_chars == 4 then
+      topleft, topright, botleft, botright = unpack(corner_chars)
+    else
+      topleft, topright, botleft, botright = '╭', '╮', '╰', '╯'
+    end
+
+    local border_lines = {topleft .. string.rep('─', width) .. topright}
     local middle_line = '│' .. string.rep(' ', width) .. '│'
     for i = 1, height do
         table.insert(border_lines, middle_line)
     end
-    table.insert(border_lines, '╰' .. string.rep('─', width) .. '╯')
+    table.insert(border_lines, botleft .. string.rep('─', width) .. botright)
 
     -- create a unlisted scratch buffer for the border
     local border_buffer = api.nvim_create_buf(false, true)

--- a/plugin/lazygit.vim
+++ b/plugin/lazygit.vim
@@ -19,6 +19,10 @@ if !exists('g:lazygit_use_neovim_remote')
   let g:lazygit_use_neovim_remote = 1
 endif
 
+if !exists('g:lazygit_floating_window_corner_chars')
+  let g:lazygit_floating_window_corner_chars = ['╭', '╮', '╰', '╯']
+endif
+
 command! LazyGit lua require'lazygit'.lazygit()
 
 command! LazyGitFilter lua require'lazygit'.lazygitfilter()


### PR DESCRIPTION
This PR fixes the issue  #23 

The default popup window corners are round and may not look so good with some font. This PR adds the option g.lazygit_floating_window_corner_chars to allow user to customize the corner characters.