### PR TITLE
Don't use -p if GIT_DIR or GIT_WORK_TREE are set

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -147,7 +147,13 @@ local function lazygit(path)
         path = project_root_dir()
     end
     open_floating_window()
-    local cmd = "lazygit " .. "-p " .. path
+    local cmd = "lazygit"
+    if not vim.env.GIT_DIR then
+        cmd = cmd .. " -g " .. path .. "/.git/"
+    end
+    if not vim.env.GIT_WORK_TREE then
+        cmd = cmd .. " -w " .. path
+    end
     exec_lazygit_command(cmd)
 end
 


### PR DESCRIPTION
Setting `-p <path>` is the same as setting `-w <path> -g <path>/.git/`,
but this eliminates the possibility that the git dir could be outside of
the work tree, or else named something besides `.git`. Use case for me
is my configuration files are VC'ed in a git repo, and checked out into
`$HOME` (the work tree). The repo is a bare repo elsewhere.
