### PR TITLE
Remove unnecessary check for git directory

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -16,29 +16,8 @@ local function is_lazygit_available()
     return vim.api.nvim_call_function("executable", { "lazygit" }) == 1
 end
 
-local function project_root_dir()
-    -- try file location first
-    local folder = trim(vim.api.nvim_call_function('expand', { '%:p:h' }))
-    local gitdir = vim.api.nvim_call_function('system', {'cd "' .. folder .. '" && git rev-parse --show-toplevel'} )
-    local isgitdir = vim.api.nvim_call_function('matchstr', { gitdir, '^fatal:.*' }) == ""
-    if isgitdir then
-        return trim(gitdir)
-    end
-
-    -- try symlinked file location instead
-    local symlink = trim(vim.api.nvim_call_function('fnamemodify', { vim.api.nvim_call_function('resolve', { vim.api.nvim_call_function('expand', { '%:p' }) }), ':h' }))
-    local gitdir = vim.api.nvim_call_function('system', { 'cd "' .. symlink .. '" && git rev-parse --show-toplevel' })
-    local isgitdir = vim.api.nvim_call_function('matchstr', { gitdir, '^fatal:.*' }) == ""
-    if isgitdir then
-        return trim(gitdir)
-    end
-
-    -- just return current working directory
-    return vim.api.nvim_call_function('getcwd', {0, 0})
-end
-
-local function exec_lazygit_command(root_dir)
-    local cmd = 'lazygit' .. ' -p "' .. root_dir .. '"'
+local function exec_lazygit_command()
+    local cmd = 'lazygit'
     if ( vim.api.nvim_call_function("has", { "win64" }) == 0 and vim.api.nvim_call_function("has", { "win32" }) == 0 and vim.api.nvim_call_function("has", { "win16" }) == 0 ) then
         cmd = "GIT_EDITOR=nvim " .. cmd
     end
@@ -129,9 +108,8 @@ local function lazygit()
         return
     end
     -- TODO: ensure that it is a valid git directory
-    local root_dir = project_root_dir()
     open_floating_window()
-    exec_lazygit_command(root_dir)
+    exec_lazygit_command()
 end
 
 local function lazygitconfig()


### PR DESCRIPTION
Lazygit already determines if the user is in a valid git directory, so checking for a git directory with vim is unnecessary. This will also make it easier to implement options to modify lazygit's parameters, such as adding "--git-dir" and "--work-tree".