### PR TITLE
fnameescape path before calling lazygit

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -146,6 +146,7 @@ local function lazygit(path)
     if path == nil then
         path = project_root_dir()
     end
+    path = vim.fn.fnameescape(path)
     open_floating_window()
     local cmd = "lazygit"
     if not vim.env.GIT_DIR then


### PR DESCRIPTION
When calling `:LazyGit` when editing a file in a directory that has spaces in
the path name, the call to lazygit would fail. Simple fix.
