### PR TITLE
Add option to use plenary.nvim to manage floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following are configuration options and their defaults.
 let g:lazygit_floating_window_winblend = 0 " transparency of floating window
 let g:lazygit_floating_window_scaling_factor = 0.9 " scaling factor for floating window
 let g:lazygit_floating_window_corner_chars = ['╭', '╮', '╰', '╯'] " customize lazygit popup window corner characters
+let g:lazygit_floating_window_use_plenary = 0 " use plenary.nvim to manage floating window if available
 let g:lazygit_use_neovim_remote = 1 " fallback to 0 if neovim-remote is not installed
 ```
 

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -67,6 +67,12 @@ local function open_floating_window()
         floating_window_scaling_factor = floating_window_scaling_factor[false]
     end
 
+    local status, plenary = pcall(require, 'plenary.window.float')
+    if status and vim.g.lazygit_floating_window_use_plenary and vim.g.lazygit_floating_window_use_plenary ~= 0 then
+        plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor)
+        return
+    end
+
     local height = math.ceil(vim.o.lines * floating_window_scaling_factor) - 1
     local width = math.ceil(vim.o.columns * floating_window_scaling_factor)
 


### PR DESCRIPTION
Lots of plugins have the same basic code to open floating windows. I'd love it
if there were a standard API for this, but the closest thing I have found is
[plenary.nvim](https://github.com/nvim-lua/plenary.nvim), which is already a
required dependency of a number of popular plugins (e.g.
[Telescope](https://github.com/nvim-lua/telescope.nvim)). Using plenary to
manage floating windows allow for a consistent UI across multiple plugins, for
example, using `winblend` for transparency.

This patch adds a configuration variable
`g:lazygit_floating_window_use_plenary`, which, if set, checks for and uses
plenary.window.float to open lazygit's floating window. Default and fallback
behavior is unchanged.

After review, if you'd like to make this the default, I wouldn't complain :)

