### PR TITLE
fix lazygit launching on Windows

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -19,9 +19,11 @@ end
 --- Get project_root_dir for git repository
 local function project_root_dir()
 
-  -- always use bash
+  -- always use bash on Unix based systems.
   local oldshell = vim.o.shell
-  vim.o.shell = 'bash'
+  if vim.fn.has('win32') == 0 then
+      vim.o.shell = 'bash'
+  end
 
   -- try submodule first
   local gitdir = fn.system('cd "' .. fn.expand('%:p:h') .. '" && git rev-parse --show-superproject-working-tree')


### PR DESCRIPTION
I use this plugin on Windows and it recently broke. I noticed it was attempting to launch lazygit using bash. Looking at the code, it seems that a change went in to enforce usage of 'bash' as the Shell. This broke functionality on Windows. This PR fixes this bug with a simple check for Win32 and not changing the shell if that's the case. 