### PR TITLE
Fix git rev path check when execute not in a git repo

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -27,7 +27,7 @@ local function project_root_dir()
 
   -- try submodule first
   local gitdir = fn.system('cd "' .. fn.expand('%:p:h') .. '" && git rev-parse --show-superproject-working-tree')
-  if gitdir ~= '' then
+  if gitdir ~= '' and fn.matchstr(gitdir, '^fatal:.*') == '' then
     vim.o.shell = oldshell
     return trim(gitdir)
   end

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -165,8 +165,9 @@ local function lazygit(path)
   if path == nil then
     path = project_root_dir()
   end
-  if path == nil or not fn.isdirectory(path .. '/.git/') then
+  if path == nil or fn.isdirectory(path .. '/.git/') == 0 then
       print('Not in a git repository')
+      return
   end
   open_floating_window()
   local cmd = 'lazygit'

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -165,6 +165,9 @@ local function lazygit(path)
   if path == nil then
     path = project_root_dir()
   end
+  if path == nil or not fn.isdirectory(path .. '/.git/') then
+      print('Not in a git repository')
+  end
   open_floating_window()
   local cmd = 'lazygit'
   if not vim.env.GIT_DIR then


### PR DESCRIPTION
when execute `git rev-parse --show-superproject-working-tree` in a non git repository directory.
It will error: `fatal: not a git repository (or any of the parent directories): .git`

and 
'lazygit -p "a not exist path"` will meet: `*fsPathError stat /xxxxxx/.git/: no such file or directory` from lazygit.