### PR TITLE
fix: improve git commit message via nvr

### DIFF
--- a/ftplugin/gitcommit.vim
+++ b/ftplugin/gitcommit.vim
@@ -1,7 +1,7 @@
 if exists("g:lazygit_opened") && g:lazygit_opened && g:lazygit_use_neovim_remote && executable("nvr")
     augroup lazygit_neovim_remote
       autocmd!
-      autocmd WinLeave <buffer> :LazyGit
-      autocmd WinLeave <buffer> :let g:lazygit_opened=0
+      autocmd BufUnload <buffer> :lua local root = require('lazygit').project_root_dir(); vim.schedule(function() require('lazygit').lazygit(root) end)
+      autocmd BufUnload <buffer> :let g:lazygit_opened=0
     augroup END
 end

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -224,4 +224,9 @@ local function lazygitconfig()
   end
 end
 
-return { lazygit = lazygit, lazygitfilter = lazygitfilter, lazygitconfig = lazygitconfig }
+return {
+  lazygit = lazygit,
+  lazygitfilter = lazygitfilter,
+  lazygitconfig = lazygitconfig,
+  project_root_dir = project_root_dir,
+}


### PR DESCRIPTION
I love the nvr implementation with LazyGit and this plugin to write my commit messages from within Neovim without spawning a new instance. But one thing that has bugged me all the time is that whenever I leave the "commit message window" to check for words, information or whatever it tries to reopen the LazyGit window (which sometimes did not work and left me with an open and empty floating window) and I have to close it again manuallly

I saw in #12 that you got a "cannot delete buffer" error when trying to use a different autocommand event for it

After playing around with it myself and reading some documentation I (think I) found the root cause for this and a working solution:

### The issue

When we close the git commit message buffer the `BufUnload` autocommand is triggered and the `LazyGit` command is called. This tries to open the floating window for lazygit internally. When opening a floating window with `nvim_open_win(border_buffer, true, border_opts)` Neovim tries to open the floating window (which at this point contains the current git commit message buffer) and then switch to the buffer provided by the `nvim_open_win` function. I am not 100% sure about the internals, but my guess is that the problem here is that this references a buffer which is about to be deleted and that this clashes the whole process :thinking: (if somebody can explain this with more details, I would like read it)

I think this is related to the description [here](https://github.com/neovim/neovim/issues/15548) but I am not completely sure :sweat_smile: 

### The solution

To mitigate this problem we defer the call of the `LazyGit` command after the deletion has been completed and it is save to call it using `vim.schedule`. Since it could happen that after unloading the commit message buffer we enter a buffer which is not related to the former git project this would then open LazyGit with the wrong project root (or even fail if not inside a git project). To be sure it opens correctly I save the current project root and call LazyGit with this afterwards.

I am currently using this modification in my daily work without any issues so far, but I am open for any ideas or changes :slightly_smiling_face: 