### PR TITLE
add vim checktime cmd to refresh buffers on lazygit exit

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -55,6 +55,7 @@ local function on_exit(job_id, code, event)
     LAZYGIT_BUFFER = nil
     LAZYGIT_LOADED = false
     vim.g.lazygit_opened = 0
+    vim.cmd('silent! :checktime')
   end
 end
 


### PR DESCRIPTION
This command will check for any changed buffers and refresh them, useful when we switch branches, stash or discard changes ( #53 )