### PR TITLE
Add LazyGitCurrentFile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ let g:lazygit_floating_window_use_plenary = 0 " use plenary.nvim to manage float
 let g:lazygit_use_neovim_remote = 1 " fallback to 0 if neovim-remote is not installed
 ```
 
-Call `:LazyGit` to start a floating window with `lazygit`.
+Call `:LazyGit` to start a floating window with `lazygit` in the current working directory.
 And set up a mapping to call `:LazyGit`:
 
 ```vim
 " setup mapping to call :LazyGit
 nnoremap <silent> <leader>gg :LazyGit<CR>
 ```
+
+Call `:LazyGitCurrentFile` to start a floating window with `lazygit` in the project root of the current file.
 
 Open the configuration file for `lazygit` directly from vim.
 

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -1,5 +1,6 @@
 local open_floating_window = require"lazygit.window".open_floating_window
 local project_root_dir  = require"lazygit.utils".project_root_dir
+local get_root  = require"lazygit.utils".get_root
 local is_lazygit_available = require"lazygit.utils".is_lazygit_available
 local is_symlink = require"lazygit.utils".is_symlink
 
@@ -67,6 +68,13 @@ local function lazygit(path)
   exec_lazygit_command(cmd)
 end
 
+--- :LazyGitCurrentFile entry point
+local function lazygitcurrentfile()
+  local current_dir = vim.fn.expand('%:p:h')
+  local git_root = get_root(current_dir)
+  lazygit(git_root)
+end
+
 --- :LazyGitFilter entry point
 local function lazygitfilter(path)
   if is_lazygit_available() ~= true then
@@ -120,6 +128,7 @@ end
 
 return {
   lazygit = lazygit,
+  lazygitcurrentfile = lazygitcurrentfile,
   lazygitfilter = lazygitfilter,
   lazygitfiltercurrentfile = lazygitfiltercurrentfile,
   lazygitconfig = lazygitconfig,

--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -25,8 +25,7 @@ local function trim(str)
 end
 
 
-local function get_root()
-  local cwd = vim.loop.cwd()
+local function get_root(cwd)
   local status, job = pcall(require, 'plenary.job')
   if not status then
     return fn.system('git rev-parse --show-toplevel')
@@ -55,7 +54,8 @@ local function project_root_dir()
     vim.o.shell = 'bash'
   end
 
-  local root = get_root()
+  local cwd = vim.loop.cwd()
+  local root = get_root(cwd)
   if root == nil then
     return nil
   end

--- a/plugin/lazygit.vim
+++ b/plugin/lazygit.vim
@@ -25,6 +25,8 @@ endif
 
 command! LazyGit lua require'lazygit'.lazygit()
 
+command! LazyGitCurrentFile lua require'lazygit'.lazygitcurrentfile()
+
 command! LazyGitFilter lua require'lazygit'.lazygitfilter()
 
 command! LazyGitFilterCurrentFile lua require'lazygit'.lazygitfiltercurrentfile()


### PR DESCRIPTION
Further to the discussion in #75, this adds a command called `LazyGitCurrentFile` that opens `lazygit` in a floating terminal at the project root of the buffer under the cursor.

This required parametrizing the `lazygit.nvim/utils.lua:get_root` function to accept a path argument.