### PR TITLE
fix: plenary.percentage_range_window returns 'win_id' and 'bufnr'

### DIFF
--- a/lua/lazygit/window.lua
+++ b/lua/lazygit/window.lua
@@ -12,8 +12,8 @@ local function open_floating_window()
 
   local status, plenary = pcall(require, 'plenary.window.float')
   if status and vim.g.lazygit_floating_window_use_plenary and vim.g.lazygit_floating_window_use_plenary ~= 0 then
-    plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor)
-    return
+    local ret = plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor)
+    return ret.win_id, ret.bufnr
   end
 
   local height = math.ceil(vim.o.lines * floating_window_scaling_factor) - 1


### PR DESCRIPTION
When using `vim.g.lazygit_floating_window_use_plenary = 1`,
Nothing is returned by `plenary.percentage_range_window` from **open_floating_window**, and `win`/`buffer` variables are `nil`.

As result LazyGit buffer is not closed in **lazygit.on_exit** callback due to an exception from `vim.api.nvim_win_close(win, true)`: _ua/lazygit.lua:28: Expected Lua number_

In addition, after LazyGit exit, the window is still opened with the text: `[Process exited 0]`

This PR fixes the issue by returning `ret.win_id, ret.bufnr` from **open_floating_window** when _plenary_ is used.


