### PR TITLE
fix: open_floating_window should return lazygit buffer instead of border_window

### DIFF
--- a/lua/lazygit/window.lua
+++ b/lua/lazygit/window.lua
@@ -81,7 +81,7 @@ local function open_floating_window()
   cmd = [[autocmd WinLeave <buffer> silent! execute 'silent bdelete! %s']]
   vim.cmd(cmd:format(border_buffer))
 
-  return win, border_window
+  return win, LAZYGIT_BUFFER
 end
 
 return {


### PR DESCRIPTION
The function **open_floating_window** returns `win, border_window`, what is incorrect.
As result, in callback **on_exit**, `vim.api.nvim_buf_is_valid(buffer)` is `false`, and LazyGit terminal buffer persists as orphan (and hidden) with text `[Process exited 0]`.

Every time LazyGit exits, an orphan terminal buffer remains , which can be checked, e.g. in Neo-tree:
```
term://~/.config/nvim//4010044:lazygit #3
term://~/.config/nvim//4010053:lazygit #7
...
```

This PR provides a fix to return `LAZYGIT_BUFFER` instead of `border_window`, so that the behavior is correct with no issues on my side.

In fact, it is not clear for me, why `LAZYGIT_BUFFER` is present, it is always set to `nil` in **on_exit** callback, probably some refactoring is required to remove `LAZYGIT_BUFFER` and `LAZYGIT_LOADED` and use local variables for corresponding buffer.


