### PR TITLE
feat: Add support for multiple lazygit config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ let g:lazygit_use_neovim_remote = 1 " fallback to 0 if neovim-remote is not inst
 
 let g:lazygit_use_custom_config_file_path = 0 " config file path is evaluated if this value is 1
 let g:lazygit_config_file_path = '' " custom config file path
+" OR
+let g:lazygit_config_file_path = [] " list of custom config file paths
 ```
 
 ```lua
@@ -77,6 +79,8 @@ vim.g.lazygit_use_neovim_remote = 1 -- fallback to 0 if neovim-remote is not ins
 
 vim.g.lazygit_use_custom_config_file_path = 0 -- config file path is evaluated if this value is 1
 vim.g.lazygit_config_file_path = '' -- custom config file path
+-- OR
+vim.g.lazygit_config_file_path = {} -- table of custom config file paths
 ```
 
 Call `:LazyGit` to start a floating window with `lazygit` in the current working directory.

--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -91,6 +91,30 @@ local function is_symlink()
   return resolved ~= fn.expand('%:p')
 end
 
+local function open_or_create_config(path)
+  if fn.empty(fn.glob(path)) == 1 then
+    -- file does not exist
+    -- check if user wants to create it
+    local answer = fn.confirm(
+      "File "
+        .. path
+        .. " does not exist.\nDo you want to create the file and populate it with the default configuration?",
+      "&Yes\n&No"
+    )
+    if answer == 2 then
+      return nil
+    end
+    if fn.isdirectory(fn.fnamemodify(path, ":h")) == false then
+      -- directory does not exist
+      fn.mkdir(fn.fnamemodify(path, ":h"), "p")
+    end
+    vim.cmd("edit " .. path)
+    vim.cmd([[execute "silent! 0read !lazygit -c"]])
+    vim.cmd([[execute "normal 1G"]])
+  else
+    vim.cmd("edit " .. path)
+  end
+end
 
 return {
   get_root = get_root,
@@ -98,4 +122,5 @@ return {
   lazygit_visited_git_repos = lazygit_visited_git_repos,
   is_lazygit_available = is_lazygit_available,
   is_symlink = is_symlink,
+  open_or_create_config = open_or_create_config,
 }


### PR DESCRIPTION
Hey @kdheepak , Thanks for creating this plugin! It's been major part of my daily workflow for over a year now.

Lazygit supports using multiple config files: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md?plain=1#L346

This PR adds code to parse vim.g.lazygit_config_file_path as a `string | table`.

PS: I'm a total noob at lua, so please let me know if anything can be done better!