### PR TITLE
fix: Cover missing edge case in resetting user's preferred shell

### DIFF
--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -57,6 +57,7 @@ local function project_root_dir()
   local cwd = vim.loop.cwd()
   local root = get_root(cwd)
   if root == nil then
+    vim.o.shell = oldshell
     return nil
   end
 


### PR DESCRIPTION
This change fixes the issue where vim starts using bash (in newly opened `:terminal` instances) instead of zsh after using `:LazyGitCurrentFile`.

Steps to reproduce issue:
1. Open `nvim` from a directory that is not part of any git repository.
2. Set vim.o.buffer to a shell that is not bash (you will not need to do this if you already don't use bash).
3. Call `:terminal` to make sure that neovim is opening the selected non-bash shell.
4. Call `:LazyGitCurrentFile` and the close out of the resulting pop-up instance of lazygit.
5. Call `:terminal` again. You should see the problem where now neovim is opening a bash instance. You can print `vim.o.shell` to see that it is bash.

After you include my change, this issue is fixed and the neovim will properly open the selected shell in step 5.