### PR TITLE
feat: Use winblend config for plenary window

### DIFF
--- a/lua/lazygit/window.lua
+++ b/lua/lazygit/window.lua
@@ -12,7 +12,7 @@ local function open_floating_window()
 
   local status, plenary = pcall(require, 'plenary.window.float')
   if status and vim.g.lazygit_floating_window_use_plenary and vim.g.lazygit_floating_window_use_plenary ~= 0 then
-    local ret = plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor)
+    local ret = plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor, {winblend=vim.g.lazygit_floating_window_winblend})
     return ret.win_id, ret.bufnr
   end
 


### PR DESCRIPTION
There is an existing user config for setting the winblend value of the lazygit floating window. This controls the background transparency of the window. However, this config option is not respected if the lazygit window is created using plenary (another user config). This change forces the plenary window to use the existing config for transparency.