### PR TITLE
fix: only set custom config file settings if not set already

### DIFF
--- a/plugin/lazygit.vim
+++ b/plugin/lazygit.vim
@@ -34,9 +34,13 @@ endif
 
 " if lazygit_use_custom_config_file_path is set to 1 the
 " lazygit_config_file_path option will be evaluated
-let g:lazygit_use_custom_config_file_path = 0
+if !exists('g:lazygit_use_custom_config_file_path')
+  let g:lazygit_use_custom_config_file_path = 0
+endif
 " path to custom config file
-let g:lazygit_config_file_path = ''
+if !exists('g:lazygit_config_file_path')
+  let g:lazygit_config_file_path = ''
+endif
 
 command! LazyGit lua require'lazygit'.lazygit()
 


### PR DESCRIPTION
Was trying to get this plugin working with my nixvim configuration and kept wondering why I couldn't get the plugin to recognize that I'd set the custom config file settings. Eventually realized it was because the plugin was loading after my init.lua and overriding what I'd set back to the defaults. This change makes it so that the defaults are only set if the variables haven't been set already, like the rest of the config variables.