### PR TITLE
Update example lazy.nvim config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ require("lazy").setup({
         dependencies = {
             "nvim-lua/plenary.nvim",
         },
+        -- setting the keybinding for LazyGit with 'keys' is recommended in
+        -- order to load the plugin when the command is run for the first time
+        keys = {
+           { "<leader>lg", "<cmd>LazyGit<cr>", desc = "LazyGit" }
+        }
     },
 })
 ```


### PR DESCRIPTION
Add a recommendation to use 'keys' to set the keybinding to load lazygit.nvim if using lazy.nvim. If the keybinding is set elsewhere, e.g. in a config() function, the plugin won't be loaded the first time this is run - the user will have to use `: LazyGit` first.