### PR TITLE
fix: use quotes to allow filtering on files with spaces in path

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -132,7 +132,7 @@ local function lazygitfilter(path)
   end
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
-  local cmd = "lazygit " .. "-f " .. path
+  local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
   exec_lazygit_command(cmd)
 end
 


### PR DESCRIPTION
:LazyGitFilterCurrentFile currently breaks if the path of the file contains a space. Fixed by wrapping the path in quotes.