### PR TITLE
feat: Add option for user's on exit callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ vim.g.lazygit_use_custom_config_file_path = 0 -- config file path is evaluated i
 vim.g.lazygit_config_file_path = '' -- custom config file path
 -- OR
 vim.g.lazygit_config_file_path = {} -- table of custom config file paths
+
+vim.g.lazygit_on_exit_callback = nil -- optional function callback when exiting lazygit (useful for example to refresh some UI elements after lazy git has made some changes)
 ```
 
 Call `:LazyGit` to start a floating window with `lazygit` in the current working directory.

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -35,6 +35,10 @@ local function on_exit(job_id, code, event)
     buffer = -1
     win = -1
   end
+
+  if vim.g.lazygit_on_exit_callback ~= nil then
+    vim.g.lazygit_on_exit_callback()
+  end
 end
 
 --- Call lazygit


### PR DESCRIPTION
## Motivation:

If I close LazyGit after having done some changes (Commit something/change branch…) I often run into some minor inconsistency with the UI on screen, that does not get updated to reflect the changes.
In particular the issue I’m having is with the color of the files inside the [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim) view. I understand this is a really insignificant issue, but I still would like to fix it.

## Proposed solution:

I have added an option that allow an user of the plugin to add a callback that is automatically executed after exiting LazyGit, so that I can put there the necessary code to refresh my UI
