### PR TITLE
fix: explicitly use cmd on windows to avodi problem using powershell

### DIFF
--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -48,10 +48,13 @@ end
 
 --- Get project_root_dir for git repository
 local function project_root_dir()
-  -- always use bash on Unix based systems.
   local oldshell = vim.o.shell
   if vim.fn.has('win32') == 0 then
+    -- always use bash on Unix based systems.
     vim.o.shell = 'bash'
+  else
+    -- always use cmd on Windows systems.
+    vim.o.shell = 'cmd'
   end
 
   local cwd = vim.loop.cwd()


### PR DESCRIPTION
If a user is on windows, and is using powershell as the default nvim shell the command at [line 69 of utils.lua](https://github.com/lucaSartore/lazygit.nvim/blob/main/lua/lazygit/utils.lua#L67C2-L67C130) won’t work due to the `&&` operator.
>  local cmd = string.format('cd "%s" && git rev-parse --show-toplevel', fn.fnamemodify(fn.resolve(fn.expand('%:p')), ':h'), root)

I fixed this by forcing the use of cmd.