### PR TITLE
fix: use double quotes for filtering on windows

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -138,8 +138,13 @@ local function lazygitfilter(path)
   end
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
-  local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
-  exec_lazygit_command(cmd)
+  if vim.loop.os_uname().sysname == "Windows_NT" then
+    local cmd = "lazygit " .. "-f " .. '"' .. path .. '"'
+    exec_lazygit_command(cmd)
+  else
+    local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
+    exec_lazygit_command(cmd)
+  end
 end
 
 --- :LazyGitFilterCurrentFile entry point


### PR DESCRIPTION
I noticed a while ago that filtering didn't work for me anymore, but I didn't have the time to look into it. Turns out the single quotes introduced in #141 break filtering for me on windows. In Lazygit itself, it showed `Filtering by ''some/path''` and left the view empty because no corresponding path was found.

I fixed that by using double quotes on windows and single quotes on other operating systems.