### PR TITLE
feat: Allow current buffer commits to show on the already worked out Git root

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -184,11 +184,9 @@ local function lazygitfilter(path, git_root)
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
 
-  local cmd
+  local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
   if git_root then
-    cmd = "lazygit " .. "-f " .. "'" .. path .. "' -p '" .. git_root .. "'"
-  else
-    cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
+    cmd = cmd .. " -p '" .. git_root .. "'"
   end
   exec_lazygit_command(cmd)
 end

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -108,7 +108,7 @@ local function lazygitlog(path)
     if type(config_path) == "table" then
       config_path = table.concat(config_path, ",")
     end
-    cmd = cmd .. " -ucf '" .. config_path .. "'" -- quote config_path to avoid whitespace errors
+    cmd = cmd .. ' -ucf "' .. config_path .. '"' -- quote config_path to avoid whitespace errors
   end
 
   if vim.env.GIT_DIR ~= nil and vim.env.GIT_WORK_TREE ~= nil then
@@ -147,7 +147,7 @@ local function lazygit(path)
     if type(config_path) == "table" then
       config_path = table.concat(config_path, ",")
     end
-    cmd = cmd .. " -ucf '" .. config_path .. "'" -- quote config_path to avoid whitespace errors
+    cmd = cmd .. ' -ucf "' .. config_path .. '"' -- quote config_path to avoid whitespace errors
   end
 
   if vim.env.GIT_DIR ~= nil and vim.env.GIT_WORK_TREE ~= nil then
@@ -184,9 +184,9 @@ local function lazygitfilter(path, git_root)
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
 
-  local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
+  local cmd = "lazygit " .. '-f "' .. path .. '"'
   if git_root then
-    cmd = cmd .. " -p '" .. git_root .. "'"
+    cmd = cmd .. ' -p "' .. git_root .. '"'
   end
   exec_lazygit_command(cmd)
 end

--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -75,8 +75,8 @@ local function lazygitgetconfigpath()
     else
       print(
         "lazygit: custom config file path: '"
-          .. vim.g.lazygit_config_file_path
-          .. "' could not be found. Returning default config"
+        .. vim.g.lazygit_config_file_path
+        .. "' could not be found. Returning default config"
       )
       return default_config_path
     end
@@ -173,7 +173,7 @@ local function lazygitcurrentfile()
 end
 
 --- :LazyGitFilter entry point
-local function lazygitfilter(path)
+local function lazygitfilter(path, git_root)
   if is_lazygit_available() ~= true then
     print("Please install lazygit. Check documentation for more information")
     return
@@ -183,7 +183,13 @@ local function lazygitfilter(path)
   end
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
-  local cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
+
+  local cmd
+  if git_root then
+    cmd = "lazygit " .. "-f " .. "'" .. path .. "' -p '" .. git_root .. "'"
+  else
+    cmd = "lazygit " .. "-f " .. "'" .. path .. "'"
+  end
   exec_lazygit_command(cmd)
 end
 
@@ -193,7 +199,7 @@ local function lazygitfiltercurrentfile()
   local git_root = get_root(current_dir)
   local file_path = vim.fn.expand("%:p")
   local relative_path = string.sub(file_path, #git_root + 2)
-  lazygitfilter(relative_path)
+  lazygitfilter(relative_path, git_root)
 end
 
 --- :LazyGitConfig entry point


### PR DESCRIPTION
We have already worked out the "git root" for the current buffer, we did this to work out the relative path. We might as well use this information when calling `lazygitfilter`.

This now allows `lazygitfiltercurrentfile` to work, whether your actual cwd is a git repository ('normal' workflow) or a project folder containing many repositories (another workflow many vim users follow).

It looks like LSP did an autoformat on the file also, I can revert those two lines if required.