### PR TITLE
update deprecated vim api usage

### DIFF
--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -57,7 +57,7 @@ local function project_root_dir()
     vim.o.shell = 'cmd'
   end
 
-  local cwd = vim.loop.cwd()
+  local cwd = (vim.uv or vim.loop).cwd()
   local root = get_root(cwd)
   if root == nil then
     vim.o.shell = oldshell


### PR DESCRIPTION
The `vim.loop` prop is deprecated and will be removed at Nvim 1.0. This PR adds support for the new `vim.uv` prop instead but keeps backward compatibility with previous versions of Nvim.