### PR TITLE
Fix command injection and errors when repo name contains spaces

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -98,7 +98,7 @@ local function lazygitlog(path)
 
   win, buffer = open_floating_window()
 
-  local cmd = "lazygit log"
+  local cmd = {"lazygit", "log"}
 
   -- set path to the root path
   _ = project_root_dir()
@@ -108,18 +108,23 @@ local function lazygitlog(path)
     if type(config_path) == "table" then
       config_path = table.concat(config_path, ",")
     end
-    cmd = cmd .. ' -ucf "' .. config_path .. '"' -- quote config_path to avoid whitespace errors
+    table.insert(cmd, "-ucf")
+    table.insert(cmd, config_path)
   end
 
   if vim.env.GIT_DIR ~= nil and vim.env.GIT_WORK_TREE ~= nil then
-    cmd = cmd .. " -w " .. vim.env.GIT_WORK_TREE .. " -g " .. vim.env.GIT_DIR
+    table.insert(cmd, "-w")
+    table.insert(cmd, vim.env.GIT_WORK_TREE)
+    table.insert(cmd, "-g")
+    table.insert(cmd, vim.env.GIT_DIR)
   elseif path == nil then
     if is_symlink() then
       path = project_root_dir()
     end
   else
     if fn.isdirectory(path) then
-      cmd = cmd .. " -p " .. path
+      table.insert(cmd, "-p")
+      table.insert(cmd, path)
     end
   end
 
@@ -137,7 +142,7 @@ local function lazygit(path)
 
   win, buffer = open_floating_window()
 
-  local cmd = "lazygit"
+  local cmd = {"lazygit"}
 
   -- set path to the root path
   _ = project_root_dir()
@@ -147,18 +152,23 @@ local function lazygit(path)
     if type(config_path) == "table" then
       config_path = table.concat(config_path, ",")
     end
-    cmd = cmd .. ' -ucf "' .. config_path .. '"' -- quote config_path to avoid whitespace errors
+    table.insert(cmd, "-ucf")
+    table.insert(cmd, config_path)
   end
 
   if vim.env.GIT_DIR ~= nil and vim.env.GIT_WORK_TREE ~= nil then
-    cmd = cmd .. " -w " .. vim.env.GIT_WORK_TREE .. " -g " .. vim.env.GIT_DIR
+    table.insert(cmd, "-w")
+    table.insert(cmd, vim.env.GIT_WORK_TREE)
+    table.insert(cmd, "-g")
+    table.insert(cmd, vim.env.GIT_DIR)
   elseif path == nil then
     if is_symlink() then
       path = project_root_dir()
     end
   else
     if fn.isdirectory(path) then
-      cmd = cmd .. " -p " .. path
+      table.insert(cmd, "-p")
+      table.insert(cmd, path)
     end
   end
 
@@ -184,9 +194,10 @@ local function lazygitfilter(path, git_root)
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
 
-  local cmd = "lazygit " .. '-f "' .. path .. '"'
+  local cmd = {"lazygit", "-f", path}
   if git_root then
-    cmd = cmd .. ' -p "' .. git_root .. '"'
+    table.insert(cmd, "-p")
+    table.insert(cmd, git_root)
   end
   exec_lazygit_command(cmd)
 end


### PR DESCRIPTION
Currently, at least `:LazyGitCurrentFile` doesn't handle paths with spaces correctly as they aren't escaped (if your current path is a valid shell script, this can also lead to code execution)
This PR changes the lazygit commands from strings to lists to avoid this problem