### PR TITLE
fix: update deprecated vim api usage

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -46,7 +46,13 @@ local function exec_lazygit_command(cmd)
   if LAZYGIT_LOADED == false then
     -- ensure that the buffer is closed on exit
     vim.g.lazygit_opened = 1
-    vim.fn.termopen(cmd, { on_exit = on_exit })
+
+    local command = {}
+    for arg in string.gmatch(cmd, "%S+") do
+        table.insert(command, arg)
+    end
+
+    vim.fn.jobstart(command, { term = true, on_exit = on_exit} )
   end
   vim.cmd("startinsert")
 end


### PR DESCRIPTION
About a month ago, lazygit started having an issue where the terminal wound’t start.

Altho I did not exactly pinpointed the issue, I noted that by replacing `termopen` (deprecated according to [the docs](https://neovim.io/doc/user/deprecated.html#deprecated-0.11)) with `jobstart` the issue went away.

I tested the change on WSL and windows.