### PR TITLE
fix: plenary usage crash

### DIFF
--- a/lua/lazygit/window.lua
+++ b/lua/lazygit/window.lua
@@ -11,9 +11,12 @@ local function get_window_pos()
 
   local status, plenary = pcall(require, 'plenary.window.float')
   if status and vim.g.lazygit_floating_window_use_plenary and vim.g.lazygit_floating_window_use_plenary ~= 0 then
-    local ret = plenary.percentage_range_window(floating_window_scaling_factor, floating_window_scaling_factor,
-      { winblend = vim.g.lazygit_floating_window_winblend })
-    return ret.win_id, ret.bufnr
+    local ret = plenary.percentage_range_window(
+      floating_window_scaling_factor,
+      floating_window_scaling_factor,
+      { winblend = vim.g.lazygit_floating_window_winblend }
+    )
+    return nil, nil, nil, nil, ret.win_id, ret.bufnr
   end
 
   local height = math.ceil(vim.o.lines * floating_window_scaling_factor) - 1
@@ -25,7 +28,10 @@ end
 
 --- open floating window with nice borders
 local function open_floating_window()
-  local width, height, row, col = get_window_pos()
+  local width, height, row, col, plenary_win, plenary_buf = get_window_pos()
+  if plenary_win and plenary_buf then
+    return plenary_win, plenary_buf
+  end
 
   local border_opts = {
     style = 'minimal',


### PR DESCRIPTION
Fixes bug created in the [commit ac4a400](https://github.com/kdheepak/lazygit.nvim/commit/ac4a400b256a63ae9d533b022db9b98d3358ef55)
**Prevent crash when using plenary.window.float for floating window**

This MR fixes a bug caused by inconsistent return values from get_window_pos() when vim.g.lazygit_floating_window_use_plenary is enabled.

**Problem**
When plenary.window.float is used, get_window_pos() returned (win_id, bufnr) instead of the expected (width, height, row, col). This led to a runtime error:
E5108: Error executing lua ...window.lua:33: attempt to perform arithmetic on local 'row' (a nil value)

**Solution**
Ensure that get_window_pos() always returns consistent values and explicitly handle the Plenary case in open_floating_window().

This prevents arithmetic operations on nil values and restores compatibility with the Plenary-based layout logic.

**Tested**
- Works correctly with and without vim.g.lazygit_floating_window_use_plenary set.
- No runtime errors on window resize or open.
- Borders and buffer correctly positioned in both modes.