### PR TITLE
fix(window): set correct window size for lazygit to render

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -59,7 +59,9 @@ local function exec_lazygit_command(cmd)
       command = cmd
     end
 
-    vim.fn.jobstart(command, { term = true, on_exit = on_exit })
+    vim.schedule(function()
+      vim.fn.jobstart(command, { term = true, on_exit = on_exit })
+    end)
   end
   vim.cmd("startinsert")
 end


### PR DESCRIPTION
since `open_floating_window` use async way `vim.defer_fn` to create window, `lazygit` executed with a sync way of `vim.fn.jobstart` in `exec_lazygit_command`, it can't get the floating window size at the banging

before:

https://github.com/user-attachments/assets/771b4099-c398-42b4-a80f-367f2d1305e7



after:

https://github.com/user-attachments/assets/12cb7381-625c-49c3-bf61-0e385ce79c76

