### PR TITLE
fix: LazyGitFilter not working when GIT_DIR and GIT_WORK_TREE are defined

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -113,7 +113,7 @@ local function lazygitlog(path)
 
   win, buffer = open_floating_window()
 
-  local cmd = {"lazygit", "log"}
+  local cmd = { "lazygit", "log" }
 
   -- set path to the root path
   _ = project_root_dir()
@@ -157,7 +157,7 @@ local function lazygit(path)
 
   win, buffer = open_floating_window()
 
-  local cmd = {"lazygit"}
+  local cmd = { "lazygit" }
 
   -- set path to the root path
   _ = project_root_dir()
@@ -209,11 +209,12 @@ local function lazygitfilter(path, git_root)
   prev_win = vim.api.nvim_get_current_win()
   win, buffer = open_floating_window()
 
-  local cmd = {"lazygit", "-f", path}
-  if git_root then
+  local cmd = { "lazygit", "-f", path }
+  if git_root and (not vim.env.GIT_DIR and not vim.env.GIT_WORK_TREE) then
     table.insert(cmd, "-p")
     table.insert(cmd, git_root)
   end
+
   exec_lazygit_command(cmd)
 end
 


### PR DESCRIPTION
### Current Error

<img width="2034" height="1382" alt="LazyGit error message" src="https://github.com/user-attachments/assets/6681bf30-89ed-43f2-b1f4-98217d82dcee" />

Bug when running `:LazyGitFilter` or `:LazyGitFilterCurrentFile` with `GIT_DIR` and `GIT_WORK_TREE` environment variables. This PR fixes the issue by not setting the path argument when those environment variables are set.