### PR TITLE
fix: get directory when using lazygit from term buffer

### DIFF
--- a/lua/lazygit.lua
+++ b/lua/lazygit.lua
@@ -192,7 +192,12 @@ end
 
 --- :LazyGitCurrentFile entry point
 local function lazygitcurrentfile()
-  local current_dir = vim.fn.expand("%:p:h")
+  local current_dir
+  if vim.bo.buftype == "terminal" then
+    current_dir = vim.fn.getcwd()
+  else
+    current_dir = vim.fn.expand("%:p:h")
+  end
   local git_root = get_root(current_dir)
   lazygit(git_root)
 end
@@ -220,6 +225,10 @@ end
 
 --- :LazyGitFilterCurrentFile entry point
 local function lazygitfiltercurrentfile()
+  if vim.bo.buftype == "terminal" then
+    print("LazyGitFilterCurrentFile is not available from terminal buffers")
+    return
+  end
   local current_dir = vim.fn.expand("%:p:h")
   local git_root = get_root(current_dir)
   local file_path = vim.fn.expand("%:p")


### PR DESCRIPTION
This fixes an annoying bug I've been running into.

When you do `:LazyGit` from a neovim terminal buffer, it fails because it tries to get the current directory.

The directory by default evaluates to something like this:
```
term://~/Documents/Projects/lazygit.nvim//18266:/usr/bin
```

Since this is always an invalid directory, lazygit won't open. As a fallback, I think it makes sense to use the current directory. 
