### PR TITLE
Trim whitespace/newlines from shell invocation

### DIFF
--- a/lua/lazygit/utils.lua
+++ b/lua/lazygit/utils.lua
@@ -28,7 +28,7 @@ end
 local function get_root(cwd)
   local status, job = pcall(require, 'plenary.job')
   if not status then
-    return fn.system('git rev-parse --show-toplevel')
+    return trim(fn.system('git rev-parse --show-toplevel'))
   end
 
   local gitroot_job = job:new({


### PR DESCRIPTION
It looks like in fish shell, a newline is part of the output. When passed verbatim, lazygit returns error that "<path>\n" is not a valid git repository.