### PR TITLE
fix: avoids modify buffer in telescope extension (#161)

### DIFF
--- a/lua/telescope/_extensions/lazygit.lua
+++ b/lua/telescope/_extensions/lazygit.lua
@@ -15,7 +15,6 @@ local function open_lazygit(prompt_buf)
 
     vim.cmd('stopinsert')
     vim.cmd([[execute "normal i"]])
-    vim.fn.feedkeys('j')
     vim.api.nvim_buf_set_keymap(0, 't', '<Esc>', '<Esc>', {noremap = true, silent = true})
 end
 


### PR DESCRIPTION
`exec_lazygit_command` run cmd using `vim.schedule`, which will be scheduled after `vim.fn.feedkeys('j')`. So the buffer is changed to be modified, and then jobstart report a `requires unmodified buffer` error.